### PR TITLE
Regenerate broken menus

### DIFF
--- a/web/sites/default/modules/features/ubn_general/ubn_general.install
+++ b/web/sites/default/modules/features/ubn_general/ubn_general.install
@@ -1485,6 +1485,19 @@ function ubn_general_update_7243() {
   };
 }
 
+// Regenerate broken menu (with duplicate items etc)
+function ubn_general_update_7244() {
+  $menus = db_or()
+    ->condition('menu_name', 'user-menu')
+    ->condition('menu_name', 'devel')
+    ->condition('menu_name', 'navigation')
+    ->condition('menu_name', 'management');
+  db_delete('menu_links')
+    ->condition($menus)
+    ->execute();
+  menu_rebuild();
+}
+
 //TODO: Disable rdf module?
 // Enable entity translation for library
 /*


### PR DESCRIPTION
Some menus contain multiple menu items. They probably come
from when rebuild_menu() has previously been called in update hook.
There was a bug in Drupal now fixed that resulted
in stale data being left in menu tables when this was done:
https://api.drupal.org/api/drupal/includes%21menu.inc/function/menu_rebuild/7.x